### PR TITLE
feat: add matrix background effect

### DIFF
--- a/global.css
+++ b/global.css
@@ -207,3 +207,17 @@ body.art footer {
 @media screen and (max-width: 768px) {
 
 }
+#matrix-bg {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    pointer-events: none;
+    display: none;
+}
+
+body.theme-hack #matrix-bg {
+    display: block;
+}

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
     
 
 <body>
+    <canvas id="matrix-bg" data-font-size="16" data-speed="50"></canvas>
     <header>
         <nav>
             <a href="index.html">Home</a>

--- a/scripts/matrix.js
+++ b/scripts/matrix.js
@@ -1,0 +1,39 @@
+const canvas = document.getElementById('matrix-bg');
+if (canvas) {
+  const ctx = canvas.getContext('2d');
+
+  function resizeCanvas() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  resizeCanvas();
+  window.addEventListener('resize', resizeCanvas);
+
+  const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const fontSize = Number(canvas.dataset.fontSize) || 16; // Taille ajustable
+  const columns = Math.floor(canvas.width / fontSize);
+  const drops = Array(columns).fill(0);
+  const speed = Number(canvas.dataset.speed) || 50; // Vitesse ajustable
+
+  function draw() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.05)';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    ctx.fillStyle = '#0F0';
+    ctx.font = fontSize + 'px monospace';
+
+    drops.forEach((y, i) => {
+      const text = letters.charAt(Math.floor(Math.random() * letters.length));
+      ctx.fillText(text, i * fontSize, y * fontSize);
+
+      if (y * fontSize > canvas.height && Math.random() > 0.975) {
+        drops[i] = 0;
+      } else {
+        drops[i] = y + 1;
+      }
+    });
+  }
+
+  window.matrixInterval = setInterval(draw, speed);
+}

--- a/test.js
+++ b/test.js
@@ -1,10 +1,35 @@
+let matrixScriptLoaded = false;
+
+function loadMatrixScript() {
+    if (matrixScriptLoaded) return;
+    const script = document.createElement('script');
+    script.src = 'scripts/matrix.js';
+    script.id = 'matrix-script';
+    document.body.appendChild(script);
+    matrixScriptLoaded = true;
+}
+
+function unloadMatrixScript() {
+    const script = document.getElementById('matrix-script');
+    if (script) {
+        script.remove();
+    }
+    if (window.matrixInterval) {
+        clearInterval(window.matrixInterval);
+        delete window.matrixInterval;
+    }
+    matrixScriptLoaded = false;
+}
+
 function changeTheme(theme) {
     if (theme === 'hack') {
         document.body.classList.add('theme-hack');
         document.body.classList.remove('art');
+        loadMatrixScript();
     } else if (theme === 'artistic') {
         document.body.classList.add('art');
         document.body.classList.remove('theme-hack');
+        unloadMatrixScript();
     }
     localStorage.setItem('selectedTheme', theme);
 }


### PR DESCRIPTION
## Summary
- insert matrix background canvas in `index.html`
- implement configurable matrix rain effect
- load matrix script dynamically for hack theme
- style canvas behind content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689622f792888322808cbcb8a768ba7c